### PR TITLE
Replace fish with mackerel during prologue

### DIFF
--- a/AutomataMod.cpp
+++ b/AutomataMod.cpp
@@ -40,10 +40,15 @@ void checkStuff(uint64_t processRamStart)
     AutomataMod::log(LogLevel::LOG_INFO, "Checker thread started. Waiting for change conditions");
 
     while (true) {
-        if (!inventoryModded && *isWorldLoaded == 1 && *playerNameSet == 1 && strncmp(currentPhase, "58_AB_BossArea_Fall", 19) == 0) {
-            AutomataMod::log(LogLevel::LOG_INFO, "Detected we are in 58_AB_BossArea_Fall. Giving VC3 inventory");
-            inventoryManager.setVc3Inventory();
-            inventoryModded = true;
+        if (!inventoryModded && *isWorldLoaded == 1 && *playerNameSet == 1) {
+            if (strncmp(currentPhase, "58_AB_BossArea_Fall", 19) == 0) {
+                AutomataMod::log(LogLevel::LOG_INFO, "Detected we are in 58_AB_BossArea_Fall. Giving VC3 inventory");
+                inventoryManager.setVc3Inventory();
+                inventoryModded = true;
+            }
+            else if (strncmp(currentPhase, "00_60_A_RobotM_Pro_Tutorial", 27) == 0) {
+                inventoryModded = inventoryManager.overrideFishedItemWithMackerel();
+            }
         }
 
         if (*isWorldLoaded == 0 && *playerNameSet == 0) {

--- a/DxWrappers.cpp
+++ b/DxWrappers.cpp
@@ -5,7 +5,7 @@
 
 namespace DxWrappers {
 
-const WCHAR* DXGISwapChainWrapper::VC3_NAME = L"VC3 Mod 1.4";
+const WCHAR* DXGISwapChainWrapper::VC3_NAME = L"VC3Modkerel 1.5";
 const UINT DXGISwapChainWrapper::VC3_LEN = (UINT)wcslen(VC3_NAME);
 
 const D2D1::ColorF DXGISwapChainWrapper::WATERMARK_COLOR = D2D1::ColorF(0.803f, 0.784f, 0.690f, 1.f);

--- a/InventoryManager.cpp
+++ b/InventoryManager.cpp
@@ -12,6 +12,10 @@ const uint32_t InventoryManager::SEVERED_CABLE_ID = 550;
 const uint32_t InventoryManager::DENTED_PLATE_ID = 610;
 const uint32_t InventoryManager::EMPTY_SLOT_ID = 0xFFFFFFFF;
 
+const uint32_t InventoryManager::FISH_AROWANA_ID = 8001;
+const uint32_t InventoryManager::FISH_MACKEREL_ID = 8016;
+const uint32_t InventoryManager::FISH_BROKEN_FIREARM_ID = 8041;
+
 InventoryManager::InventoryManager(uint64_t itemTableRamStart) : _firstSlot(reinterpret_cast<ItemSlot*>(itemTableRamStart))
 {}
 
@@ -19,6 +23,16 @@ InventoryManager::ItemSlot* InventoryManager::getItemSlotById(uint32_t itemId)
 {
     for (ItemSlot* i = _firstSlot; i != _firstSlot + MAX_SLOT_COUNT; ++i) {
         if (i->itemId == itemId)
+            return i;
+    }
+
+    return nullptr;
+}
+
+InventoryManager::ItemSlot* InventoryManager::getItemSlotByIdRange(uint32_t itemIdStart, uint32_t itemIdEnd)
+{
+    for (ItemSlot* i = _firstSlot; i != _firstSlot + MAX_SLOT_COUNT; ++i) {
+        if (i->itemId >= itemIdStart && i->itemId <= itemIdEnd)
             return i;
     }
 
@@ -75,6 +89,20 @@ void InventoryManager::setVc3Inventory()
     AutomataMod::log(LogLevel::LOG_INFO, "Current Dented Plates: " + std::to_string(dentedPlateSlot->quantity));
     AutomataMod::log(LogLevel::LOG_INFO, "Current Severed Cables: " + std::to_string(severedCableSlot->quantity));
     AutomataMod::log(LogLevel::LOG_INFO, "Done adding inventory.");
+}
+
+bool InventoryManager::overrideFishedItemWithMackerel()
+{
+    ItemSlot* firstFish = getItemSlotByIdRange(FISH_AROWANA_ID, FISH_BROKEN_FIREARM_ID);
+
+    if (firstFish) {
+        AutomataMod::log(LogLevel::LOG_INFO, "Overriding fish with id " + std::to_string(firstFish->itemId));
+        firstFish->itemId = FISH_MACKEREL_ID;
+        AutomataMod::log(LogLevel::LOG_INFO, "Done overwriting fish in inventory.");
+
+        return true;
+    }
+    return false;
 }
 
 } // namespace AutomataMod

--- a/InventoryManager.hpp
+++ b/InventoryManager.hpp
@@ -18,6 +18,10 @@ public:
     static const uint32_t DENTED_PLATE_ID;
     static const uint32_t EMPTY_SLOT_ID;
 
+    static const uint32_t FISH_AROWANA_ID;
+    static const uint32_t FISH_BROKEN_FIREARM_ID;
+    static const uint32_t FISH_MACKEREL_ID;
+
 private:
     ItemSlot* const _firstSlot; // The memory address that the item table starts at
     static const int MAX_SLOT_COUNT; // the total number of inventory slots the game supports
@@ -28,7 +32,12 @@ public:
     // Returns the slot for the given index, or nullptr if not found
     ItemSlot* getItemSlotById(uint32_t itemId);
 
+    // Returns the slot for the given index range (inclusive), or nullptr if not found
+    ItemSlot* getItemSlotByIdRange(uint32_t itemIdStart, uint32_t itemIdEnd);
+
     void setVc3Inventory();
+
+    bool overrideFishedItemWithMackerel();
 };
 
 } // namespace AutomataMod


### PR DESCRIPTION
* Add logic to replace any fished items during `00_60_A_RobotM_Pro_Tutorial` with Mackerel. 
* * Currently does not require fishing at Flooded City/does not replace Pod B.