### PR TITLE
Various Smalls Fixes

### DIFF
--- a/DLLMain.cpp
+++ b/DLLMain.cpp
@@ -4,7 +4,6 @@
 #include <d3d11.h>
 #include <dxgi1_2.h>
 #include <memory>
-#include <ntstatus.h>
 #include <stdexcept>
 #include <string>
 #include <thread>

--- a/src/infra/HashCheck.cpp
+++ b/src/infra/HashCheck.cpp
@@ -77,7 +77,7 @@ std::vector<u8> readFile(const std::string &fileName) {
 	return fileBuff;
 }
 
-std::string QueryhNierBinaryHash() {
+std::string QueryNierBinaryHash() {
 	std::string fileName = getNierFileName();
 	std::vector<u8> fileBuff = readFile(fileName);
 
@@ -116,7 +116,7 @@ bool NierVerisonInfo::operator==(NierVersion other) const { return m_version == 
 
 std::optional<NierVerisonInfo> QueryNierBinaryVersion() {
 	// Query the nier binary hash
-	std::string exeHash = QueryhNierBinaryHash();
+	std::string exeHash = QueryNierBinaryHash();
 
 #ifdef _DEBUG
 	std::string out;

--- a/src/infra/IAT.cpp
+++ b/src/infra/IAT.cpp
@@ -14,7 +14,7 @@ IATHook::~IATHook() {
 		DWORD oldPermissions;
 		VirtualProtect(&(m_thunkIAT->u1.Function), sizeof(ULONGLONG), PAGE_EXECUTE_READWRITE, &oldPermissions);
 		m_thunkIAT->u1.Function = m_originalFunction;
-		VirtualProtect(&(m_thunkIAT->u1.Function), sizeof(ULONGLONG), oldPermissions, nullptr);
+		VirtualProtect(&(m_thunkIAT->u1.Function), sizeof(ULONGLONG), oldPermissions, &oldPermissions);
 	}
 
 	m_thunkIAT = nullptr;
@@ -82,7 +82,7 @@ void IATHook::readImportDescriptor(
 				VirtualProtect(&(m_thunkIAT->u1.Function), sizeof(ULONGLONG), PAGE_EXECUTE_READWRITE, &oldPermissions);
 				m_originalFunction = m_thunkIAT->u1.Function;
 				m_thunkIAT->u1.Function = (ULONGLONG)replacementFunction;
-				VirtualProtect(&(m_thunkIAT->u1.Function), sizeof(ULONGLONG), oldPermissions, nullptr);
+				VirtualProtect(&(m_thunkIAT->u1.Function), sizeof(ULONGLONG), oldPermissions, &oldPermissions);
 				AutomataMod::log(AutomataMod::LogLevel::LOG_INFO, "Successfully hooked {}", functionName);
 				return;
 			}


### PR DESCRIPTION
Fixed typos in HashCheck .h & cpp.

Removed useless include ntstatus.h spewing marco redefinition warnings.

Fixed  C6387  _Param_(4)' could be '0':  this does not adhere to the specification for the function 'VirtualProtect'