### PR TITLE
AutomataSpeedrunMod 1.13

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,4 +20,12 @@ add_subdirectory(fmt)
 
 file(GLOB_RECURSE MOD_SOURCES src/*.cpp)
 add_library(xinput1_4 SHARED DLLMain.cpp ${MOD_SOURCES} xinput.def)
-target_link_libraries(xinput1_4 fmt::fmt d3d11 d2d1 dwrite dxgi bcrypt)
+target_link_libraries(xinput1_4 fmt::fmt d3d11 d2d1 dwrite dxgi bcrypt dinput8 dxguid)
+
+include(CTest)
+if(BUILD_TESTING)
+	add_executable(controller_input_tests tests/ControllerInputTests.cpp src/ControllerInput.cpp)
+	target_compile_definitions(controller_input_tests PRIVATE CONTROLLER_INPUT_TESTING)
+	target_link_libraries(controller_input_tests dinput8 dxguid)
+	add_test(NAME controller_input_tests COMMAND controller_input_tests)
+endif()

--- a/DLLMain.cpp
+++ b/DLLMain.cpp
@@ -11,6 +11,7 @@
 #include <winuser.h>
 
 #include "AutomataMod.hpp"
+#include "ControllerInput.hpp"
 #include "com/FactoryWrapper2.hpp"
 #include "com/WrapperPointer.hpp"
 #include "infra/DLL.hpp"
@@ -18,6 +19,7 @@
 #include "infra/IAT.hpp"
 #include "infra/Log.hpp"
 #include "infra/ModConfig.hpp"
+#include "infra/Persistence.hpp"
 #include "infra/constants.hpp"
 
 using namespace AutomataMod;
@@ -26,6 +28,8 @@ namespace {
 
 WORD lastXInputButtons = 0;
 bool kbInputSetModActiveFlag = true;
+bool kbInputToggleDisplayFlag = true;
+bool kbInputStartCalibrationFlag = true;
 std::unique_ptr<DLL> xinput;
 std::unique_ptr<std::thread> checkerThread;
 std::unique_ptr<std::thread> keyboardInputThread;
@@ -72,13 +76,37 @@ HRESULT WINAPI D3D11CreateDeviceHooked(
 void handleKeyboardInput() {
 	keyboardInputThread = std::unique_ptr<std::thread>(new std::thread([]() {
 		while (!shouldStopChecker) {
-			if (GetAsyncKeyState(VK_HOME) != 0 && kbInputSetModActiveFlag) {
+			const bool homePressed = (GetAsyncKeyState(VK_HOME) & 0x8000) != 0;
+			const bool f9Pressed = (GetAsyncKeyState(VK_F9) & 0x8000) != 0;
+			const bool f10Pressed = (GetAsyncKeyState(VK_F10) & 0x8000) != 0;
+			if (homePressed && kbInputSetModActiveFlag) {
 				ModChecker *modChecker = ModChecker::get();
 				modChecker->setModActive(!modChecker->getModActive());
 				AutomataMod::log(AutomataMod::LogLevel::LOG_INFO, "Mod toggled from keyboard input");
 				kbInputSetModActiveFlag = false;
-			} else if (GetAsyncKeyState(VK_HOME) == 0) {
+			} else if (!homePressed) {
 				kbInputSetModActiveFlag = true;
+			}
+
+			if (f9Pressed && kbInputToggleDisplayFlag) {
+				const auto style = ControllerInput::toggleDisplayStyle();
+				const bool playStation = style == ControllerInput::DisplayStyle::PlayStation;
+				Persistence::setPlayStationButtonDisplay(playStation);
+				AutomataMod::log(
+						AutomataMod::LogLevel::LOG_INFO, "Button display changed to {}",
+						playStation ? "PlayStation" : "Xbox"
+				);
+				kbInputToggleDisplayFlag = false;
+			} else if (!f9Pressed) {
+				kbInputToggleDisplayFlag = true;
+			}
+
+			if (f10Pressed && kbInputStartCalibrationFlag) {
+				ControllerInput::startCalibration();
+				AutomataMod::log(AutomataMod::LogLevel::LOG_INFO, "Controller mapping calibration started");
+				kbInputStartCalibrationFlag = false;
+			} else if (!f10Pressed) {
+				kbInputStartCalibrationFlag = true;
 			}
 
 			std::this_thread::sleep_for(std::chrono::duration<double, std::milli>(33));
@@ -133,6 +161,11 @@ void init() {
 	}
 
 	AutomataMod::ModChecker::set(std::make_unique<ModChecker>(addresses));
+	ControllerInput::setDisplayStyle(
+			Persistence::getPlayStationButtonDisplay() ? ControllerInput::DisplayStyle::PlayStation
+																	 : ControllerInput::DisplayStyle::Xbox
+	);
+	ControllerInput::start();
 
 	checkerThread = std::unique_ptr<std::thread>(new std::thread([]() {
 		ModChecker *modChecker = ModChecker::get();
@@ -186,6 +219,7 @@ BOOL WINAPI DllMain(HINSTANCE hInst, DWORD reason, LPVOID) {
 			keyboardInputThread = nullptr;
 		}
 
+		ControllerInput::stop();
 		AutomataMod::ModChecker::set(nullptr);
 		factory = nullptr;
 		d3dCreateDeviceHook = nullptr;
@@ -245,6 +279,15 @@ DWORD WINAPI XInputGetState(_In_ DWORD dwUserIndex, _Out_ XINPUT_STATE *pState) 
 		return ERROR_DEVICE_NOT_CONNECTED;
 
 	DWORD result = ptr(dwUserIndex, pState);
+	if (dwUserIndex == 0) {
+		if (result == ERROR_SUCCESS && pState) {
+			ControllerInput::updateXInput(
+					pState->Gamepad.wButtons, pState->Gamepad.bLeftTrigger, pState->Gamepad.bRightTrigger
+			);
+		} else {
+			ControllerInput::clearXInput();
+		}
+	}
 
 	// Check for mod toggle button combo
 	ModChecker *modChecker = ModChecker::get();

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Mod that aims to make the NieR: Automata speedrun more tolerable.
 Done! The game should now display a VC3Mod watermark on screen when loaded.  
 The mod only makes changes **if you start as run from a new game!**
 
+The on-screen display also shows FPS, frame count, left-stick magnitude, and the buttons currently held on a controller. Xbox/XInput controllers and DirectInput-compatible controllers are supported. All controllers use Xbox button names by default. Press F9 to switch every controller between Xbox names (`A`, `LB`, `LT`) and PlayStation symbols (`×`, `○`, `□`, `△`, `L1`, `L2`). The selected style is saved between game reboots. In PlayStation mode, the four face symbols use one symbol font with matching visual height and a stable baseline.
+
+DirectInput button and trigger ordering is not standardized. If controls appear under the wrong names, press F10 and follow the 12 on-screen prompts. Release all controls first, then press each requested control in order. Trigger axes and unusual button orders are detected during this process, and the completed mapping is saved between game reboots. PS/Guide and touchpad buttons are intentionally not displayed or included in calibration.
+
 ## Additional steps when running on Linux through Proton
 
 A startup script runs on the first launch of the game that will determine whether to use NieRAutomata.exe or NieRAutomataCompat.exe. 

--- a/src/ControllerInput.cpp
+++ b/src/ControllerInput.cpp
@@ -1,0 +1,662 @@
+#include "ControllerInput.hpp"
+#ifndef CONTROLLER_INPUT_TESTING
+#include "infra/Persistence.hpp"
+#endif
+#include <Windows.h>
+#define DIRECTINPUT_VERSION 0x0800
+#include <Xinput.h>
+#include <dinput.h>
+#include <wrl/client.h>
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace {
+
+using namespace AutomataMod;
+using Microsoft::WRL::ComPtr;
+
+constexpr u32 LEFT_TRIGGER_SHIFT = 16;
+constexpr u32 RIGHT_TRIGGER_SHIFT = 24;
+constexpr u16 AXIS_INPUT_THRESHOLD = 4096;
+constexpr auto DEVICE_RESCAN_INTERVAL = std::chrono::seconds(3);
+constexpr auto POLL_INTERVAL = std::chrono::milliseconds(8);
+
+enum class LogicalInput : size_t {
+	South,
+	East,
+	West,
+	North,
+	LeftBumper,
+	RightBumper,
+	LeftTrigger,
+	RightTrigger,
+	Back,
+	Start,
+	LeftStick,
+	RightStick,
+	Count,
+};
+
+constexpr size_t LOGICAL_INPUT_COUNT = static_cast<size_t>(LogicalInput::Count);
+
+enum class BindingType : u8 {
+	Button = 1,
+	AxisPositive = 2,
+	AxisNegative = 3,
+};
+
+struct InputBinding {
+	BindingType type;
+	u8 index;
+	u16 baseline;
+};
+
+struct InputLabel {
+	const wchar_t *xbox;
+	const wchar_t *playStation;
+};
+
+constexpr std::array<InputLabel, LOGICAL_INPUT_COUNT> INPUT_LABELS{{
+		{L"A", L"\u00D7"},
+		{L"B", L"\u25CB"},
+		{L"X", L"\u25A1"},
+		{L"Y", L"\u25B3"},
+		{L"LB", L"L1"},
+		{L"RB", L"R1"},
+		{L"LT", L"L2"},
+		{L"RT", L"R2"},
+		{L"Back", L"Share"},
+		{L"Start", L"Options"},
+		{L"L3", L"L3"},
+		{L"R3", L"R3"},
+}};
+
+constexpr std::array<InputBinding, LOGICAL_INPUT_COUNT> DEFAULT_BINDINGS{{
+		{BindingType::Button, 0, 0},
+		{BindingType::Button, 1, 0},
+		{BindingType::Button, 2, 0},
+		{BindingType::Button, 3, 0},
+		{BindingType::Button, 4, 0},
+		{BindingType::Button, 5, 0},
+		{BindingType::Button, 6, 0},
+		{BindingType::Button, 7, 0},
+		{BindingType::Button, 8, 0},
+		{BindingType::Button, 9, 0},
+		{BindingType::Button, 10, 0},
+		{BindingType::Button, 11, 0},
+}};
+
+struct XInputButtonLabel {
+	u16 mask;
+	LogicalInput input;
+};
+
+constexpr std::array<XInputButtonLabel, 10> XINPUT_BUTTONS{{
+		{XINPUT_GAMEPAD_A, LogicalInput::South},
+		{XINPUT_GAMEPAD_B, LogicalInput::East},
+		{XINPUT_GAMEPAD_X, LogicalInput::West},
+		{XINPUT_GAMEPAD_Y, LogicalInput::North},
+		{XINPUT_GAMEPAD_LEFT_SHOULDER, LogicalInput::LeftBumper},
+		{XINPUT_GAMEPAD_RIGHT_SHOULDER, LogicalInput::RightBumper},
+		{XINPUT_GAMEPAD_BACK, LogicalInput::Back},
+		{XINPUT_GAMEPAD_START, LogicalInput::Start},
+		{XINPUT_GAMEPAD_LEFT_THUMB, LogicalInput::LeftStick},
+		{XINPUT_GAMEPAD_RIGHT_THUMB, LogicalInput::RightStick},
+}};
+
+struct CalibrationState {
+	bool active = false;
+	bool baselineCaptured = false;
+	bool waitingForRelease = true;
+	size_t step = 0;
+	std::array<u16, 6> baseline{};
+	std::array<InputBinding, LOGICAL_INPUT_COUNT> workingBindings = DEFAULT_BINDINGS;
+};
+
+std::atomic<u32> xinputState{0};
+std::atomic<bool> xinputConnected{false};
+std::atomic<bool> pollerRunning{false};
+std::atomic<ControllerInput::DisplayStyle> displayStyle{ControllerInput::DisplayStyle::Xbox};
+std::thread pollerThread;
+
+std::mutex directInputMutex;
+ControllerInput::DirectInputSnapshot directInputState;
+bool directInputConnected = false;
+std::array<InputBinding, LOGICAL_INPUT_COUNT> inputBindings = DEFAULT_BINDINGS;
+CalibrationState calibration;
+
+struct DirectInputDevice {
+	ComPtr<IDirectInputDevice8W> device;
+};
+
+struct DeviceEnumerationContext {
+	IDirectInput8W *directInput;
+	HWND window;
+	std::vector<DirectInputDevice> *devices;
+};
+
+const wchar_t *getLabel(LogicalInput input, ControllerInput::DisplayStyle style) {
+	const InputLabel &labels = INPUT_LABELS[static_cast<size_t>(input)];
+	return style == ControllerInput::DisplayStyle::Xbox ? labels.xbox : labels.playStation;
+}
+
+std::wstring getPrefix(ControllerInput::DisplayStyle style) {
+	return style == ControllerInput::DisplayStyle::Xbox ? L"Buttons [Xbox]:" : L"Buttons [PS]:";
+}
+
+void appendButton(std::wstring &result, const std::wstring &label) {
+	result += L' ';
+	result += label;
+}
+
+std::wstring formatXInputButtons(u32 packedState, ControllerInput::DisplayStyle style) {
+	const u16 buttons = static_cast<u16>(packedState);
+	const u8 leftTrigger = static_cast<u8>(packedState >> LEFT_TRIGGER_SHIFT);
+	const u8 rightTrigger = static_cast<u8>(packedState >> RIGHT_TRIGGER_SHIFT);
+
+	std::wstring result = getPrefix(style);
+	bool hasInput = false;
+	for (const auto &[mask, input] : XINPUT_BUTTONS) {
+		if ((buttons & mask) != 0) {
+			appendButton(result, getLabel(input, style));
+			hasInput = true;
+		}
+	}
+
+	if (leftTrigger > XINPUT_GAMEPAD_TRIGGER_THRESHOLD) {
+		appendButton(result, getLabel(LogicalInput::LeftTrigger, style));
+		hasInput = true;
+	}
+	if (rightTrigger > XINPUT_GAMEPAD_TRIGGER_THRESHOLD) {
+		appendButton(result, getLabel(LogicalInput::RightTrigger, style));
+		hasInput = true;
+	}
+
+	if ((buttons & XINPUT_GAMEPAD_DPAD_UP) != 0) {
+		appendButton(result, L"D-Up");
+		hasInput = true;
+	}
+	if ((buttons & XINPUT_GAMEPAD_DPAD_RIGHT) != 0) {
+		appendButton(result, L"D-Right");
+		hasInput = true;
+	}
+	if ((buttons & XINPUT_GAMEPAD_DPAD_DOWN) != 0) {
+		appendButton(result, L"D-Down");
+		hasInput = true;
+	}
+	if ((buttons & XINPUT_GAMEPAD_DPAD_LEFT) != 0) {
+		appendButton(result, L"D-Left");
+		hasInput = true;
+	}
+
+	if (!hasInput) {
+		result += L" -";
+	}
+	return result;
+}
+
+bool appendPov(std::wstring &result, u32 pov) {
+	if (pov == ~0u) {
+		return false;
+	}
+
+	pov %= 36000;
+	if (pov >= 31500 || pov <= 4500) {
+		appendButton(result, L"D-Up");
+	}
+	if (pov >= 4500 && pov <= 13500) {
+		appendButton(result, L"D-Right");
+	}
+	if (pov >= 13500 && pov <= 22500) {
+		appendButton(result, L"D-Down");
+	}
+	if (pov >= 22500 && pov <= 31500) {
+		appendButton(result, L"D-Left");
+	}
+	return true;
+}
+
+bool isBindingActive(const ControllerInput::DirectInputSnapshot &state, const InputBinding &binding) {
+	if (binding.type == BindingType::Button) {
+		return binding.index < state.buttons.size() && (state.buttons[binding.index] & 0x80) != 0;
+	}
+	if (binding.index >= state.axes.size()) {
+		return false;
+	}
+
+	const int delta = static_cast<int>(state.axes[binding.index]) - static_cast<int>(binding.baseline);
+	if (binding.type == BindingType::AxisPositive) {
+		return delta > AXIS_INPUT_THRESHOLD;
+	}
+	return delta < -static_cast<int>(AXIS_INPUT_THRESHOLD);
+}
+
+std::wstring formatDirectInputButtons(
+		const ControllerInput::DirectInputSnapshot &state, ControllerInput::DisplayStyle style,
+		const std::array<InputBinding, LOGICAL_INPUT_COUNT> &bindings
+) {
+	std::wstring result = getPrefix(style);
+	bool hasInput = false;
+	for (size_t index = 0; index < bindings.size(); ++index) {
+		if (isBindingActive(state, bindings[index])) {
+			appendButton(result, getLabel(static_cast<LogicalInput>(index), style));
+			hasInput = true;
+		}
+	}
+
+	hasInput = appendPov(result, state.pov) || hasInput;
+	if (!hasInput) {
+		result += L" -";
+	}
+	return result;
+}
+
+bool anyButtonPressed(const ControllerInput::DirectInputSnapshot &state) {
+	return std::any_of(state.buttons.begin(), state.buttons.end(), [](u8 value) { return (value & 0x80) != 0; });
+}
+
+bool controlsReleased(const ControllerInput::DirectInputSnapshot &state, const CalibrationState &stateMachine) {
+	if (anyButtonPressed(state)) {
+		return false;
+	}
+	for (size_t index = 0; index < state.axes.size(); ++index) {
+		const int delta = static_cast<int>(state.axes[index]) - static_cast<int>(stateMachine.baseline[index]);
+		if (delta > AXIS_INPUT_THRESHOLD || delta < -static_cast<int>(AXIS_INPUT_THRESHOLD)) {
+			return false;
+		}
+	}
+	return true;
+}
+
+std::optional<InputBinding> findPressedButton(const ControllerInput::DirectInputSnapshot &state) {
+	for (size_t index = 0; index < state.buttons.size(); ++index) {
+		if ((state.buttons[index] & 0x80) != 0) {
+			return InputBinding{BindingType::Button, static_cast<u8>(index), 0};
+		}
+	}
+	return std::nullopt;
+}
+
+std::optional<InputBinding> findMovedAxis(
+		const ControllerInput::DirectInputSnapshot &state, const CalibrationState &stateMachine
+) {
+	int largestMagnitude = AXIS_INPUT_THRESHOLD;
+	int selectedDelta = 0;
+	size_t selectedIndex = state.axes.size();
+	for (size_t index = 0; index < state.axes.size(); ++index) {
+		const int delta = static_cast<int>(state.axes[index]) - static_cast<int>(stateMachine.baseline[index]);
+		const int magnitude = delta < 0 ? -delta : delta;
+		if (magnitude > largestMagnitude) {
+			largestMagnitude = magnitude;
+			selectedDelta = delta;
+			selectedIndex = index;
+		}
+	}
+
+	if (selectedIndex == state.axes.size()) {
+		return std::nullopt;
+	}
+	return InputBinding{
+			selectedDelta > 0 ? BindingType::AxisPositive : BindingType::AxisNegative,
+			static_cast<u8>(selectedIndex), stateMachine.baseline[selectedIndex]
+	};
+}
+
+u32 encodeBinding(const InputBinding &binding) {
+	return static_cast<u32>(binding.type) << 28 | static_cast<u32>(binding.baseline) << 8 | binding.index;
+}
+
+std::optional<InputBinding> decodeBinding(u32 encoded) {
+	const auto type = static_cast<BindingType>((encoded >> 28) & 0x0F);
+	const u8 index = static_cast<u8>(encoded & 0xFF);
+	const u16 baseline = static_cast<u16>((encoded >> 8) & 0xFFFF);
+	if (type == BindingType::Button && index < 128) {
+		return InputBinding{type, index, 0};
+	}
+	if ((type == BindingType::AxisPositive || type == BindingType::AxisNegative) && index < 6) {
+		return InputBinding{type, index, baseline};
+	}
+	return std::nullopt;
+}
+
+std::array<u32, LOGICAL_INPUT_COUNT> encodeBindings(
+		const std::array<InputBinding, LOGICAL_INPUT_COUNT> &bindings
+) {
+	std::array<u32, LOGICAL_INPUT_COUNT> encoded{};
+	for (size_t index = 0; index < bindings.size(); ++index) {
+		encoded[index] = encodeBinding(bindings[index]);
+	}
+	return encoded;
+}
+
+void loadPersistedBindings() {
+#ifndef CONTROLLER_INPUT_TESTING
+	std::array<u32, LOGICAL_INPUT_COUNT> encoded{};
+	if (!Persistence::getControllerMapping(encoded.data(), encoded.size())) {
+		return;
+	}
+
+	std::array<InputBinding, LOGICAL_INPUT_COUNT> loaded{};
+	for (size_t index = 0; index < encoded.size(); ++index) {
+		const auto binding = decodeBinding(encoded[index]);
+		if (!binding.has_value()) {
+			return;
+		}
+		loaded[index] = *binding;
+	}
+	std::lock_guard<std::mutex> lock(directInputMutex);
+	inputBindings = loaded;
+#endif
+}
+
+void saveBindings(const std::array<InputBinding, LOGICAL_INPUT_COUNT> &bindings) {
+#ifndef CONTROLLER_INPUT_TESTING
+	const auto encoded = encodeBindings(bindings);
+	Persistence::setControllerMapping(encoded.data(), encoded.size());
+#endif
+}
+
+std::optional<std::array<InputBinding, LOGICAL_INPUT_COUNT>> updateCalibration(
+		const ControllerInput::DirectInputSnapshot &state
+) {
+	if (!calibration.active) {
+		return std::nullopt;
+	}
+
+	if (!calibration.baselineCaptured) {
+		if (anyButtonPressed(state)) {
+			return std::nullopt;
+		}
+		calibration.baseline = state.axes;
+		calibration.baselineCaptured = true;
+		calibration.waitingForRelease = false;
+		return std::nullopt;
+	}
+
+	if (calibration.waitingForRelease) {
+		if (controlsReleased(state, calibration)) {
+			calibration.waitingForRelease = false;
+		}
+		return std::nullopt;
+	}
+
+	std::optional<InputBinding> binding = findPressedButton(state);
+	const auto input = static_cast<LogicalInput>(calibration.step);
+	if (!binding.has_value() && (input == LogicalInput::LeftTrigger || input == LogicalInput::RightTrigger)) {
+		binding = findMovedAxis(state, calibration);
+	}
+	if (!binding.has_value()) {
+		return std::nullopt;
+	}
+
+	calibration.workingBindings[calibration.step] = *binding;
+	++calibration.step;
+	calibration.waitingForRelease = true;
+	if (calibration.step < LOGICAL_INPUT_COUNT) {
+		return std::nullopt;
+	}
+
+	inputBindings = calibration.workingBindings;
+	calibration.active = false;
+	return inputBindings;
+}
+
+std::wstring getCalibrationText(ControllerInput::DisplayStyle style) {
+	if (!calibration.baselineCaptured || calibration.waitingForRelease) {
+		return L"Controller mapping: release all controls";
+	}
+	const auto input = static_cast<LogicalInput>(calibration.step);
+	return L"Map [" + std::to_wstring(calibration.step + 1) + L"/" + std::to_wstring(LOGICAL_INPUT_COUNT) +
+			L"]: press " + getLabel(input, style);
+}
+
+bool hasDirectInput(const ControllerInput::DirectInputSnapshot &state) {
+	return state.pov != ~0u || anyButtonPressed(state);
+}
+
+BOOL CALLBACK findProcessWindow(HWND window, LPARAM parameter) {
+	DWORD processId = 0;
+	GetWindowThreadProcessId(window, &processId);
+	if (processId != GetCurrentProcessId() || !IsWindowVisible(window)) {
+		return TRUE;
+	}
+
+	*reinterpret_cast<HWND *>(parameter) = window;
+	return FALSE;
+}
+
+HWND getProcessWindow() {
+	HWND window = nullptr;
+	EnumWindows(findProcessWindow, reinterpret_cast<LPARAM>(&window));
+	return window;
+}
+
+void setAxisRange(IDirectInputDevice8W *device, DWORD axisOffset) {
+	DIPROPRANGE range{};
+	range.diph.dwSize = sizeof(DIPROPRANGE);
+	range.diph.dwHeaderSize = sizeof(DIPROPHEADER);
+	range.diph.dwObj = axisOffset;
+	range.diph.dwHow = DIPH_BYOFFSET;
+	range.lMin = 0;
+	range.lMax = 65535;
+	device->SetProperty(DIPROP_RANGE, &range.diph);
+}
+
+BOOL CALLBACK enumerateController(const DIDEVICEINSTANCEW *instance, VOID *parameter) {
+	auto *context = reinterpret_cast<DeviceEnumerationContext *>(parameter);
+	ComPtr<IDirectInputDevice8W> device;
+	HRESULT result = context->directInput->CreateDevice(instance->guidInstance, device.GetAddressOf(), nullptr);
+	if (FAILED(result)) {
+		return DIENUM_CONTINUE;
+	}
+
+	result = device->SetDataFormat(&c_dfDIJoystick2);
+	if (FAILED(result)) {
+		return DIENUM_CONTINUE;
+	}
+
+	result = device->SetCooperativeLevel(context->window, DISCL_BACKGROUND | DISCL_NONEXCLUSIVE);
+	if (FAILED(result)) {
+		return DIENUM_CONTINUE;
+	}
+
+	for (DWORD offset : {DIJOFS_X, DIJOFS_Y, DIJOFS_Z, DIJOFS_RX, DIJOFS_RY, DIJOFS_RZ}) {
+		setAxisRange(device.Get(), offset);
+	}
+	device->Acquire();
+	context->devices->push_back({device});
+	return DIENUM_CONTINUE;
+}
+
+std::vector<DirectInputDevice> enumerateControllers(IDirectInput8W *directInput) {
+	std::vector<DirectInputDevice> devices;
+	HWND window = getProcessWindow();
+	if (!window) {
+		return devices;
+	}
+
+	DeviceEnumerationContext context{directInput, window, &devices};
+	directInput->EnumDevices(DI8DEVCLASS_GAMECTRL, enumerateController, &context, DIEDFL_ATTACHEDONLY);
+	return devices;
+}
+
+u16 normalizeAxis(LONG value) { return static_cast<u16>(std::clamp<LONG>(value, 0, 65535)); }
+
+bool pollController(DirectInputDevice &device, ControllerInput::DirectInputSnapshot &snapshot) {
+	HRESULT result = device.device->Poll();
+	if (FAILED(result)) {
+		result = device.device->Acquire();
+		while (result == DIERR_INPUTLOST) {
+			result = device.device->Acquire();
+		}
+		if (FAILED(result)) {
+			return false;
+		}
+	}
+
+	DIJOYSTATE2 state{};
+	result = device.device->GetDeviceState(sizeof(state), &state);
+	if (FAILED(result)) {
+		return false;
+	}
+
+	std::copy(std::begin(state.rgbButtons), std::end(state.rgbButtons), snapshot.buttons.begin());
+	snapshot.axes = {
+			normalizeAxis(state.lX), normalizeAxis(state.lY), normalizeAxis(state.lZ),
+			normalizeAxis(state.lRx), normalizeAxis(state.lRy), normalizeAxis(state.lRz)
+	};
+	snapshot.pov = state.rgdwPOV[0];
+	return true;
+}
+
+void runDirectInputPoller() {
+	ComPtr<IDirectInput8W> directInput;
+	HRESULT result = DirectInput8Create(
+			GetModuleHandleW(nullptr), DIRECTINPUT_VERSION, IID_IDirectInput8W,
+			reinterpret_cast<void **>(directInput.GetAddressOf()), nullptr
+	);
+	if (FAILED(result)) {
+		ControllerInput::clearDirectInput();
+		return;
+	}
+
+	std::vector<DirectInputDevice> devices;
+	auto nextDeviceScan = std::chrono::steady_clock::now();
+	while (pollerRunning.load(std::memory_order_acquire)) {
+		const auto now = std::chrono::steady_clock::now();
+		if (now >= nextDeviceScan) {
+			devices = enumerateControllers(directInput.Get());
+			nextDeviceScan = now + DEVICE_RESCAN_INTERVAL;
+		}
+
+		bool receivedState = false;
+		ControllerInput::DirectInputSnapshot selectedState;
+		for (auto &device : devices) {
+			ControllerInput::DirectInputSnapshot state;
+			if (!pollController(device, state)) {
+				continue;
+			}
+
+			if (!receivedState || hasDirectInput(state)) {
+				selectedState = state;
+				receivedState = true;
+			}
+			if (hasDirectInput(state)) {
+				break;
+			}
+		}
+
+		if (receivedState) {
+			ControllerInput::updateDirectInput(selectedState);
+		} else {
+			ControllerInput::clearDirectInput();
+		}
+		std::this_thread::sleep_for(POLL_INTERVAL);
+	}
+
+	for (auto &device : devices) {
+		device.device->Unacquire();
+	}
+	ControllerInput::clearDirectInput();
+}
+
+} // namespace
+
+namespace AutomataMod::ControllerInput {
+
+void start() {
+	loadPersistedBindings();
+	bool expected = false;
+	if (!pollerRunning.compare_exchange_strong(expected, true, std::memory_order_acq_rel)) {
+		return;
+	}
+	pollerThread = std::thread(runDirectInputPoller);
+}
+
+void stop() {
+	pollerRunning.store(false, std::memory_order_release);
+	if (pollerThread.joinable()) {
+		pollerThread.join();
+	}
+	clearDirectInput();
+}
+
+void setDisplayStyle(DisplayStyle style) { displayStyle.store(style, std::memory_order_release); }
+
+DisplayStyle getDisplayStyle() { return displayStyle.load(std::memory_order_acquire); }
+
+DisplayStyle toggleDisplayStyle() {
+	const DisplayStyle next = getDisplayStyle() == DisplayStyle::Xbox ? DisplayStyle::PlayStation : DisplayStyle::Xbox;
+	setDisplayStyle(next);
+	return next;
+}
+
+void startCalibration() {
+	std::lock_guard<std::mutex> lock(directInputMutex);
+	calibration = {};
+	calibration.active = true;
+}
+
+bool isCalibrationActive() {
+	std::lock_guard<std::mutex> lock(directInputMutex);
+	return calibration.active;
+}
+
+void updateXInput(u16 buttons, u8 leftTrigger, u8 rightTrigger) {
+	u32 packedState = buttons;
+	packedState |= static_cast<u32>(leftTrigger) << LEFT_TRIGGER_SHIFT;
+	packedState |= static_cast<u32>(rightTrigger) << RIGHT_TRIGGER_SHIFT;
+	xinputState.store(packedState, std::memory_order_relaxed);
+	xinputConnected.store(true, std::memory_order_release);
+}
+
+void clearXInput() {
+	xinputConnected.store(false, std::memory_order_release);
+	xinputState.store(0, std::memory_order_relaxed);
+}
+
+void updateDirectInput(const DirectInputSnapshot &state) {
+	std::optional<std::array<InputBinding, LOGICAL_INPUT_COUNT>> completedMapping;
+	{
+		std::lock_guard<std::mutex> lock(directInputMutex);
+		directInputState = state;
+		directInputConnected = true;
+		completedMapping = updateCalibration(state);
+	}
+	if (completedMapping.has_value()) {
+		saveBindings(*completedMapping);
+	}
+}
+
+void clearDirectInput() {
+	std::lock_guard<std::mutex> lock(directInputMutex);
+	directInputState = {};
+	directInputConnected = false;
+}
+
+std::wstring getPressedButtons() {
+	const DisplayStyle style = getDisplayStyle();
+	{
+		std::lock_guard<std::mutex> lock(directInputMutex);
+		if (calibration.active) {
+			return getCalibrationText(style);
+		}
+	}
+
+	if (xinputConnected.load(std::memory_order_acquire)) {
+		return formatXInputButtons(xinputState.load(std::memory_order_relaxed), style);
+	}
+
+	std::lock_guard<std::mutex> lock(directInputMutex);
+	return directInputConnected ? formatDirectInputButtons(directInputState, style, inputBindings)
+									 : getPrefix(style) + L" -";
+}
+
+} // namespace AutomataMod::ControllerInput

--- a/src/ControllerInput.hpp
+++ b/src/ControllerInput.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "infra/defs.hpp"
+#include <array>
+#include <string>
+
+namespace AutomataMod::ControllerInput {
+
+enum class DisplayStyle : u8 {
+	Xbox,
+	PlayStation,
+};
+
+struct DirectInputSnapshot {
+	std::array<u8, 128> buttons{};
+	std::array<u16, 6> axes{};
+	u32 pov = ~0u;
+};
+
+/// Starts discovery and polling for DirectInput-compatible controllers.
+void start();
+
+/// Stops controller discovery and releases DirectInput devices.
+void stop();
+
+/// Selects Xbox or PlayStation names independently of the connected controller.
+void setDisplayStyle(DisplayStyle style);
+DisplayStyle getDisplayStyle();
+DisplayStyle toggleDisplayStyle();
+
+/// Starts an interactive mapping sequence for non-standard DirectInput layouts.
+void startCalibration();
+bool isCalibrationActive();
+
+/// Stores the latest state for player one's XInput controller.
+void updateXInput(u16 buttons, u8 leftTrigger, u8 rightTrigger);
+
+/// Clears the XInput state when player one's controller is disconnected.
+void clearXInput();
+
+/// Stores the latest state from a DirectInput-compatible controller.
+void updateDirectInput(const DirectInputSnapshot &state);
+
+/// Clears the DirectInput state when no compatible controller is available.
+void clearDirectInput();
+
+/// Returns a compact list of the controls that are currently held.
+std::wstring getPressedButtons();
+
+} // namespace AutomataMod::ControllerInput

--- a/src/com/SwapChainWrapper1.cpp
+++ b/src/com/SwapChainWrapper1.cpp
@@ -1,5 +1,6 @@
 #include "SwapChainWrapper1.hpp"
 #include "AutomataMod.hpp"
+#include "ControllerInput.hpp"
 #include "StickState.hpp"
 #include "infra/Log.hpp"
 #include "infra/constants.hpp"
@@ -8,15 +9,19 @@
 #include <fmt/xchar.h>
 #include <random>
 #include <string>
+#include <utility>
+#include <vector>
 
 #undef max
 #include <algorithm>
 
 namespace {
 
-const float SCREEN_WIDTH = 1600.f;
 const float SCREEN_HEIGHT = 900.f;
 const float WATERMARK_TEXT_SIZE = 15.25f;
+const wchar_t *PLAYSTATION_SYMBOL_FONT = L"Segoe UI Symbol";
+constexpr wchar_t PLAYSTATION_CROSS_LABEL = L'\u00D7';
+constexpr wchar_t PLAYSTATION_CROSS_DISPLAY = L'\u2715';
 
 const D2D1::ColorF WATERMARK_COLOR = D2D1::ColorF(0.803f, 0.784f, 0.690f, 1.f);
 const D2D1::ColorF SHADOW_COLOR = D2D1::ColorF(0.f, 0.f, 0.f, 0.3f);
@@ -28,6 +33,43 @@ const D2D1_BITMAP_PROPERTIES1 BITMAP_PROPERTIES = {
 		D2D1_BITMAP_OPTIONS_TARGET | D2D1_BITMAP_OPTIONS_CANNOT_DRAW,
 		nullptr
 };
+
+bool isPlayStationFaceSymbol(wchar_t character) noexcept {
+	return character == PLAYSTATION_CROSS_DISPLAY || character == L'\u25CB' || character == L'\u25A1' ||
+			character == L'\u25B3';
+}
+
+bool containsPlayStationFaceSymbol(const std::wstring &line) noexcept {
+	return std::any_of(line.begin(), line.end(), isPlayStationFaceSymbol);
+}
+
+void useFullHeightPlayStationCross(std::wstring &line) noexcept {
+	for (wchar_t &character : line) {
+		if (character == PLAYSTATION_CROSS_LABEL) {
+			// U+2715 has the same full-height geometry as the circle, square,
+			// and triangle in Segoe UI Symbol. U+00D7 is a smaller math glyph.
+			character = PLAYSTATION_CROSS_DISPLAY;
+		}
+	}
+}
+
+bool stylePlayStationFaceSymbols(
+		IDWriteTextLayout *layout, const std::wstring &line, FLOAT fontSize
+) noexcept {
+	for (size_t index = 0; index < line.size(); ++index) {
+		if (!isPlayStationFaceSymbol(line[index])) {
+			continue;
+		}
+
+		const DWRITE_TEXT_RANGE range{static_cast<UINT32>(index), 1};
+		if (FAILED(layout->SetFontFamilyName(PLAYSTATION_SYMBOL_FONT, range)) ||
+				FAILED(layout->SetFontWeight(DWRITE_FONT_WEIGHT_NORMAL, range)) ||
+				FAILED(layout->SetFontSize(fontSize, range))) {
+			return false;
+		}
+	}
+	return true;
+}
 
 } // namespace
 
@@ -74,7 +116,6 @@ void DXGISwapChainWrapper1::renderWatermark() {
 		resetLocation(screenSize);
 	}
 
-	float xscale = screenSize.width * (1.f / SCREEN_WIDTH) * 1.2;
 	float yscale = screenSize.height * (1.f / SCREEN_HEIGHT) * 1.2;
 	float heightScale = WATERMARK_TEXT_SIZE * yscale;
 
@@ -91,38 +132,70 @@ void DXGISwapChainWrapper1::renderWatermark() {
 	}
 
 	FLOAT textHeight = _textFormat->GetFontSize();
-	FLOAT rectHeight = textHeight * 3; // * 3 for three lines, the mod name and the FPS count
+	FLOAT rectHeight = textHeight * 4;
 	std::wstring logo = getLogo();
 	std::chrono::duration<float, std::milli> frameDeltaMilli = now - _lastFrame;
 	std::wstring fpsString = calculateFps(frameDeltaMilli.count());
 	std::wstring stickMagnitudeString = getJoystickMagnitude();
+	std::wstring buttonsString = AutomataMod::ControllerInput::getPressedButtons();
 
-	std::wstring *maxLenString;
-	if (fpsString.size() > logo.size()) {
-		maxLenString = &fpsString;
-	} else {
-		maxLenString = &logo;
+	std::array<std::wstring, 4> displayLines{logo, fpsString, stickMagnitudeString, buttonsString};
+	FLOAT rectWidth = 0.f;
+	std::vector<ComPtr<IDWriteTextLayout>> lineLayouts;
+	lineLayouts.reserve(displayLines.size());
+	DWRITE_LINE_METRICS hudLineMetrics{};
+	bool haveHudLineMetrics = false;
+	for (std::wstring &line : displayLines) {
+		useFullHeightPlayStationCross(line);
+		ComPtr<IDWriteTextLayout> lineLayout;
+		hr = _dwFactory->CreateTextLayout(
+				line.c_str(), static_cast<UINT32>(line.size()), _textFormat.Get(), screenSize.width, screenSize.height,
+				lineLayout.GetAddressOf()
+		);
+		if (!SUCCEEDED(hr)) {
+			AutomataMod::log(AutomataMod::LogLevel::LOG_ERROR, "Failed to create IDWriteTextLayout");
+			return;
+		}
+
+		hr = lineLayout->SetWordWrapping(DWRITE_WORD_WRAPPING_NO_WRAP);
+		if (FAILED(hr)) {
+			AutomataMod::log(AutomataMod::LogLevel::LOG_ERROR, "Failed to disable HUD text wrapping");
+			return;
+		}
+
+		if (!haveHudLineMetrics) {
+			UINT32 lineMetricCount = 0;
+			hr = lineLayout->GetLineMetrics(&hudLineMetrics, 1, &lineMetricCount);
+			if (FAILED(hr) || lineMetricCount != 1) {
+				AutomataMod::log(AutomataMod::LogLevel::LOG_ERROR, "Failed to get the HUD baseline");
+				return;
+			}
+			haveHudLineMetrics = true;
+		}
+
+		if (!stylePlayStationFaceSymbols(lineLayout.Get(), line, textHeight)) {
+			AutomataMod::log(AutomataMod::LogLevel::LOG_ERROR, "Failed to normalize PlayStation face symbols");
+			return;
+		}
+		if (containsPlayStationFaceSymbol(line)) {
+			hr = lineLayout->SetLineSpacing(
+					DWRITE_LINE_SPACING_METHOD_UNIFORM, hudLineMetrics.height, hudLineMetrics.baseline
+			);
+			if (FAILED(hr)) {
+				AutomataMod::log(AutomataMod::LogLevel::LOG_ERROR, "Failed to align PlayStation button text");
+				return;
+			}
+		}
+
+		DWRITE_TEXT_METRICS metrics;
+		hr = lineLayout->GetMetrics(&metrics);
+		if (!SUCCEEDED(hr)) {
+			AutomataMod::log(AutomataMod::LogLevel::LOG_ERROR, "Failed to get DWRITE_TEXT_METRICS");
+			return;
+		}
+		rectWidth = std::max(rectWidth, metrics.widthIncludingTrailingWhitespace);
+		lineLayouts.emplace_back(std::move(lineLayout));
 	}
-
-	// Use IDWriteTextLayout to get accurate text rectangle size
-	ComPtr<IDWriteTextLayout> layout;
-	hr = _dwFactory->CreateTextLayout(
-			maxLenString->c_str(), maxLenString->size(), _textFormat.Get(), screenSize.width, screenSize.height,
-			layout.GetAddressOf()
-	);
-	if (!SUCCEEDED(hr)) {
-		AutomataMod::log(AutomataMod::LogLevel::LOG_ERROR, "Failed to create IDWriteTextLayout");
-		return;
-	}
-
-	DWRITE_TEXT_METRICS metrics;
-	hr = layout->GetMetrics(&metrics);
-	if (!SUCCEEDED(hr)) {
-		AutomataMod::log(AutomataMod::LogLevel::LOG_ERROR, "Failed to get DWRITE_TEXT_METRICS");
-		return;
-	}
-
-	float rectWidth = metrics.width;
 	if (_dvdMode) {
 		float xBound = _location.x + rectWidth;
 		float yBound = _location.y + rectHeight;
@@ -147,8 +220,6 @@ void DXGISwapChainWrapper1::renderWatermark() {
 			_location.y = std::fmax(std::fmin(_location.y, screenSize.height - rectHeight), 0.f);
 	}
 
-	D2D1_RECT_F rect = {_location.x, _location.y, _location.x + rectWidth * xscale, _location.y + rectHeight};
-
 	_ASSERT(_textFormat);
 	_ASSERT(_shadowBrush);
 	_ASSERT(_brush);
@@ -161,35 +232,18 @@ void DXGISwapChainWrapper1::renderWatermark() {
 	_deviceContext->SetTarget(bitmap.Get());
 	_deviceContext->SetTransform(root);
 
-	// Draw shadow behind our text
-	_deviceContext->SetTransform(D2D1::Matrix3x2F::Translation(2, 2));
-	_deviceContext->DrawText(logo.c_str(), logo.size(), _textFormat.Get(), rect, _shadowBrush.Get());
+	for (size_t lineIndex = 0; lineIndex < displayLines.size(); ++lineIndex) {
+		const FLOAT yOffset = textHeight * static_cast<FLOAT>(lineIndex);
+		const D2D1_POINT_2F lineOrigin = D2D1::Point2F(_location.x, _location.y + yOffset);
+		_deviceContext->DrawTextLayout(
+				D2D1::Point2F(lineOrigin.x + 2.f, lineOrigin.y + 2.f), lineLayouts[lineIndex].Get(), _shadowBrush.Get(),
+				D2D1_DRAW_TEXT_OPTIONS_NONE
+		);
+		_deviceContext->DrawTextLayout(
+				lineOrigin, lineLayouts[lineIndex].Get(), _brush.Get(), D2D1_DRAW_TEXT_OPTIONS_NONE
+		);
+	}
 	_deviceContext->SetTransform(root);
-
-	// Draw main text
-	_deviceContext->DrawText(logo.c_str(), logo.size(), _textFormat.Get(), rect, _brush.Get());
-
-	// Draw FPS and Frame Counter Shadow
-	_deviceContext->SetTransform(D2D1::Matrix3x2F::Translation(2, textHeight + 2));
-	_deviceContext->DrawText(fpsString.c_str(), fpsString.length(), _textFormat.Get(), rect, _shadowBrush.Get());
-	_deviceContext->SetTransform(root);
-
-	// Draw FPS and Frame Counter
-	_deviceContext->SetTransform(D2D1::Matrix3x2F::Translation(0, textHeight));
-	_deviceContext->DrawText(fpsString.c_str(), fpsString.length(), _textFormat.Get(), rect, _brush.Get());
-
-	// Draw Joystick Magnitude shadow
-	_deviceContext->SetTransform(D2D1::Matrix3x2F::Translation(2, 2 + (textHeight * 2)));
-	_deviceContext->DrawText(
-			stickMagnitudeString.c_str(), stickMagnitudeString.length(), _textFormat.Get(), rect, _shadowBrush.Get()
-	);
-	_deviceContext->SetTransform(root);
-
-	// Draw Joystick Magnitude
-	_deviceContext->SetTransform(D2D1::Matrix3x2F::Translation(0, textHeight * 2));
-	_deviceContext->DrawText(
-			stickMagnitudeString.c_str(), stickMagnitudeString.length(), _textFormat.Get(), rect, _brush.Get()
-	);
 
 	_deviceContext->EndDraw();
 	_deviceContext->SetTarget(oldTarget.Get());
@@ -244,7 +298,7 @@ std::wstring DXGISwapChainWrapper1::getLogo() {
 
 	if (checker && checker->getInMenu()) {
 		return fmt::format(
-				L"SpeedrunMod {} ({}), Press Home or hold X & Y to toggle mod", AutomataMod::Constants::getWVersion(),
+				L"SpeedrunMod {} ({}), Home/X+Y: mod, F9: labels, F10: remap", AutomataMod::Constants::getWVersion(),
 				activatedString
 		);
 	}

--- a/src/infra/Persistence.cpp
+++ b/src/infra/Persistence.cpp
@@ -1,3 +1,4 @@
+#include "Persistence.hpp"
 #include "Log.hpp"
 #include <Windows.h>
 #include <string>
@@ -6,6 +7,8 @@
 namespace {
 const char *ENABLED_KEY_PATH = "Software\\AutomataSpeedrunMod";
 const char *ENABLED_VALUE_NAME = "ModEnabled";
+const char *BUTTON_DISPLAY_VALUE_NAME = "PlayStationButtonDisplay";
+const char *CONTROLLER_MAPPING_VALUE_NAME = "ControllerButtonMapping";
 
 // Wrapper for HKEY to provide automatic closing to any open registry keys
 struct RegKey {
@@ -72,6 +75,90 @@ bool getEnabledFlag() {
 	} else {
 		AutomataMod::log(
 				AutomataMod::LogLevel::LOG_ERROR, "Failed to open persistent enabled flag. {}", getWindowsErrorString(status)
+		);
+	}
+	return false;
+}
+
+void setPlayStationButtonDisplay(bool enabled) {
+	DWORD value = enabled;
+	RegKey regKey;
+	LSTATUS status = RegCreateKeyExA(
+			HKEY_CURRENT_USER, ENABLED_KEY_PATH, 0, NULL, REG_OPTION_NON_VOLATILE, KEY_WRITE, NULL, &regKey.key, NULL
+	);
+	if (status != ERROR_SUCCESS) {
+		AutomataMod::log(
+				AutomataMod::LogLevel::LOG_ERROR, "Failed to open persistent button display setting. {}",
+				getWindowsErrorString(status)
+		);
+		return;
+	}
+
+	status = RegSetValueExA(regKey.key, BUTTON_DISPLAY_VALUE_NAME, 0, REG_DWORD, (BYTE *)&value, sizeof(DWORD));
+	if (status != ERROR_SUCCESS) {
+		AutomataMod::log(
+				AutomataMod::LogLevel::LOG_ERROR, "Failed to save button display setting. {}",
+				getWindowsErrorString(status)
+		);
+	}
+}
+
+bool getPlayStationButtonDisplay() {
+	DWORD value = 0;
+	DWORD valueSize = sizeof(DWORD);
+	LSTATUS status = RegGetValueA(
+			HKEY_CURRENT_USER, ENABLED_KEY_PATH, BUTTON_DISPLAY_VALUE_NAME, RRF_RT_REG_DWORD, NULL, &value, &valueSize
+	);
+	if (status == ERROR_SUCCESS) {
+		return value == 1;
+	}
+	if (status == ERROR_FILE_NOT_FOUND) {
+		setPlayStationButtonDisplay(false);
+	} else {
+		AutomataMod::log(
+				AutomataMod::LogLevel::LOG_ERROR, "Failed to read button display setting. {}",
+				getWindowsErrorString(status)
+		);
+	}
+	return false;
+}
+
+void setControllerMapping(const u32 *mapping, size_t count) {
+	RegKey regKey;
+	LSTATUS status = RegCreateKeyExA(
+			HKEY_CURRENT_USER, ENABLED_KEY_PATH, 0, NULL, REG_OPTION_NON_VOLATILE, KEY_WRITE, NULL, &regKey.key, NULL
+	);
+	if (status != ERROR_SUCCESS) {
+		AutomataMod::log(
+				AutomataMod::LogLevel::LOG_ERROR, "Failed to open persistent controller mapping. {}",
+				getWindowsErrorString(status)
+		);
+		return;
+	}
+
+	const DWORD byteCount = static_cast<DWORD>(count * sizeof(u32));
+	status = RegSetValueExA(
+			regKey.key, CONTROLLER_MAPPING_VALUE_NAME, 0, REG_BINARY, reinterpret_cast<const BYTE *>(mapping), byteCount
+	);
+	if (status != ERROR_SUCCESS) {
+		AutomataMod::log(
+				AutomataMod::LogLevel::LOG_ERROR, "Failed to save controller mapping. {}", getWindowsErrorString(status)
+		);
+	}
+}
+
+bool getControllerMapping(u32 *mapping, size_t count) {
+	DWORD byteCount = static_cast<DWORD>(count * sizeof(u32));
+	const LSTATUS status = RegGetValueA(
+			HKEY_CURRENT_USER, ENABLED_KEY_PATH, CONTROLLER_MAPPING_VALUE_NAME, RRF_RT_REG_BINARY, NULL, mapping,
+			&byteCount
+	);
+	if (status == ERROR_SUCCESS) {
+		return byteCount == count * sizeof(u32);
+	}
+	if (status != ERROR_FILE_NOT_FOUND && status != ERROR_MORE_DATA) {
+		AutomataMod::log(
+				AutomataMod::LogLevel::LOG_ERROR, "Failed to read controller mapping. {}", getWindowsErrorString(status)
 		);
 	}
 	return false;

--- a/src/infra/Persistence.hpp
+++ b/src/infra/Persistence.hpp
@@ -1,8 +1,17 @@
 #pragma once
 
+#include "defs.hpp"
+#include <cstddef>
+
 namespace Persistence {
 
 void setEnabledFlag(bool enabled);
 bool getEnabledFlag();
+
+void setPlayStationButtonDisplay(bool enabled);
+bool getPlayStationButtonDisplay();
+
+void setControllerMapping(const u32 *mapping, size_t count);
+bool getControllerMapping(u32 *mapping, size_t count);
 
 } // namespace Persistence

--- a/src/infra/constants.cpp
+++ b/src/infra/constants.cpp
@@ -2,8 +2,8 @@
 #include <string>
 
 namespace {
-const std::string VC3_VERSION("1.12");
-const std::wstring VC3_WVERSION(L"1.12");
+const std::string VC3_VERSION("1.13");
+const std::wstring VC3_WVERSION(L"1.13");
 } // namespace
 
 namespace AutomataMod {

--- a/tests/ControllerInputTests.cpp
+++ b/tests/ControllerInputTests.cpp
@@ -1,0 +1,141 @@
+#include "ControllerInput.hpp"
+#include <Windows.h>
+#include <Xinput.h>
+#include <array>
+#include <iostream>
+
+namespace {
+
+using AutomataMod::ControllerInput::DirectInputSnapshot;
+
+bool expect(const std::wstring &expected) {
+	const std::wstring actual = AutomataMod::ControllerInput::getPressedButtons();
+	if (actual == expected) {
+		return true;
+	}
+
+	std::wcerr << L"Expected: " << expected << L"\nActual:   " << actual << L'\n';
+	return false;
+}
+
+DirectInputSnapshot neutralState() {
+	DirectInputSnapshot state;
+	state.axes.fill(32768);
+	return state;
+}
+
+void mapButton(u8 buttonIndex) {
+	DirectInputSnapshot pressed = neutralState();
+	pressed.buttons[buttonIndex] = 0x80;
+	AutomataMod::ControllerInput::updateDirectInput(pressed);
+	AutomataMod::ControllerInput::updateDirectInput(neutralState());
+}
+
+void mapAxis(u8 axisIndex, u16 value) {
+	DirectInputSnapshot pressed = neutralState();
+	pressed.axes[axisIndex] = value;
+	AutomataMod::ControllerInput::updateDirectInput(pressed);
+	AutomataMod::ControllerInput::updateDirectInput(neutralState());
+}
+
+} // namespace
+
+int main() {
+	using namespace AutomataMod;
+
+	ControllerInput::clearXInput();
+	ControllerInput::clearDirectInput();
+	ControllerInput::setDisplayStyle(ControllerInput::DisplayStyle::Xbox);
+	if (!expect(L"Buttons [Xbox]: -")) {
+		return 1;
+	}
+
+	ControllerInput::updateXInput(
+			XINPUT_GAMEPAD_A | XINPUT_GAMEPAD_Y | XINPUT_GAMEPAD_LEFT_SHOULDER | XINPUT_GAMEPAD_DPAD_UP,
+			XINPUT_GAMEPAD_TRIGGER_THRESHOLD + 1, 0
+	);
+	if (!expect(L"Buttons [Xbox]: A Y LB LT D-Up")) {
+		return 1;
+	}
+
+	ControllerInput::setDisplayStyle(ControllerInput::DisplayStyle::PlayStation);
+	if (!expect(L"Buttons [PS]: \u00D7 \u25B3 L1 L2 D-Up")) {
+		return 1;
+	}
+
+	// The default DirectInput mapping follows the standard gamepad face-button order.
+	ControllerInput::clearXInput();
+	DirectInputSnapshot standardState = neutralState();
+	standardState.buttons[0] = 0x80;
+	standardState.buttons[1] = 0x80;
+	standardState.buttons[2] = 0x80;
+	standardState.buttons[3] = 0x80;
+	ControllerInput::updateDirectInput(standardState);
+	if (!expect(L"Buttons [PS]: \u00D7 \u25CB \u25A1 \u25B3")) {
+		return 1;
+	}
+
+	// Unmapped axes, including touch coordinates, must not appear as L2/R2.
+	DirectInputSnapshot touchMovement = neutralState();
+	touchMovement.axes[3] = 62000;
+	touchMovement.axes[4] = 1000;
+	ControllerInput::updateDirectInput(touchMovement);
+	if (!expect(L"Buttons [PS]: -")) {
+		return 1;
+	}
+
+	// Calibrate a deliberately shuffled controller and a shared bidirectional trigger axis.
+	ControllerInput::startCalibration();
+	ControllerInput::updateDirectInput(neutralState());
+	if (!expect(L"Map [1/12]: press \u00D7")) {
+		return 1;
+	}
+
+	mapButton(2);  // South / Cross
+	mapButton(0);  // East / Circle
+	mapButton(1);  // West / Square
+	mapButton(3);  // North / Triangle
+	mapButton(5);  // L1
+	mapButton(4);  // R1
+	mapAxis(2, 60000); // L2
+	mapAxis(2, 1000);  // R2
+	mapButton(9);  // Back / Share
+	mapButton(8);  // Start / Options
+	mapButton(11); // L3
+	mapButton(10); // R3
+
+	if (ControllerInput::isCalibrationActive()) {
+		std::wcerr << L"Calibration did not finish\n";
+		return 1;
+	}
+
+	DirectInputSnapshot calibratedState = neutralState();
+	calibratedState.buttons[2] = 0x80;
+	calibratedState.buttons[0] = 0x80;
+	calibratedState.buttons[1] = 0x80;
+	calibratedState.buttons[3] = 0x80;
+	calibratedState.buttons[5] = 0x80;
+	calibratedState.buttons[4] = 0x80;
+	calibratedState.axes[2] = 60000;
+	ControllerInput::updateDirectInput(calibratedState);
+	if (!expect(L"Buttons [PS]: \u00D7 \u25CB \u25A1 \u25B3 L1 R1 L2")) {
+		return 1;
+	}
+
+	ControllerInput::setDisplayStyle(ControllerInput::DisplayStyle::Xbox);
+	if (!expect(L"Buttons [Xbox]: A B X Y LB RB LT")) {
+		return 1;
+	}
+
+	// Touch-axis movement remains ignored after trigger calibration.
+	touchMovement = neutralState();
+	touchMovement.axes[3] = 62000;
+	touchMovement.axes[4] = 1000;
+	ControllerInput::updateDirectInput(touchMovement);
+	if (!expect(L"Buttons [Xbox]: -")) {
+		return 1;
+	}
+
+	ControllerInput::clearDirectInput();
+	return expect(L"Buttons [Xbox]: -") ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

This PR proposes the **Standard build only** and updates the displayed version to 1.13. It does not include the Practice or Debug toolbox.

- Adds an on-screen display for currently held controller inputs
- Supports XInput and DirectInput-compatible controllers
- Uses Xbox button names by default for every controller
- Adds F9 switching between Xbox and PlayStation labels
- Adds F10 calibration for non-standard DirectInput button and trigger layouts
- Handles DirectInput trigger axes and unusual button ordering
- Ignores PS/Guide and touchpad inputs
- Normalizes PlayStation face-symbol sizes and keeps the Buttons/Stick row spacing stable
- Saves the selected display style and calibration for the current Windows user

## Validation

- x64 Release build: passed
- Controller input tests: 1/1 passed
- The PR contains no Practice/Debug profiles, timer, diagnostics, or F1-F4 toolbox handling
- Final live-game review by the maintainer is still welcome before release

If this fits the project, would you consider merging it and publishing the next official release as **AutomataSpeedrunMod 1.13**?